### PR TITLE
Fixed build errors on VS2013 and earlier.

### DIFF
--- a/ALAC/codec/ALACBitUtilities.h
+++ b/ALAC/codec/ALACBitUtilities.h
@@ -55,8 +55,7 @@ enum
     
 
 typedef enum
-{
-    
+{    
     ID_SCE = 0,						/* Single Channel Element   */
     ID_CPE = 1,						/* Channel Pair Element     */
     ID_CCE = 2,						/* Coupling Channel Element */
@@ -65,7 +64,7 @@ typedef enum
     ID_PCE = 5,
     ID_FIL = 6,
     ID_END = 7
-} ELEMENT_TYPE;
+} AELEMENT_TYPE;
 
 // types
 typedef struct BitBuffer

--- a/ALAC/codec/ag_dec.c
+++ b/ALAC/codec/ag_dec.c
@@ -53,6 +53,10 @@
 #define ALWAYS_INLINE
 #endif
 
+#ifdef _MSC_VER 
+#define inline __inline
+#endif
+
 /*	And on the subject of the CodeWarrior x86 compiler and inlining, I reworked a lot of this
 	to help the compiler out.   In many cases this required manual inlining or a macro.  Sorry
 	if it is ugly but the performance gains are well worth it.

--- a/ALAC/codec/ag_enc.c
+++ b/ALAC/codec/ag_enc.c
@@ -54,6 +54,10 @@
 #define ALWAYS_INLINE
 #endif
 
+#ifdef _MSC_VER 
+#define inline __inline
+#endif
+
 
 /*	And on the subject of the CodeWarrior x86 compiler and inlining, I reworked a lot of this
 	to help the compiler out.   In many cases this required manual inlining or a macro.  Sorry

--- a/ALAC/codec/dp_dec.c
+++ b/ALAC/codec/dp_dec.c
@@ -36,6 +36,10 @@
 #define ALWAYS_INLINE
 #endif
 
+#ifdef _MSC_VER 
+#define inline __inline
+#endif
+
 #if TARGET_CPU_PPC && (__MWERKS__ >= 0x3200)
 // align loops to a 16 byte boundary to make the G5 happy
 #pragma function_align 16

--- a/ALAC/codec/dp_enc.c
+++ b/ALAC/codec/dp_enc.c
@@ -35,6 +35,10 @@
 #define ALWAYS_INLINE
 #endif
 
+#ifdef _MSC_VER 
+#define inline __inline
+#endif
+
 #if TARGET_CPU_PPC && (__MWERKS__ >= 0x3200)
 // align loops to a 16 byte boundary to make the G5 happy
 #pragma function_align 16

--- a/binding.cc
+++ b/binding.cc
@@ -121,7 +121,7 @@ private:
 
     // Build cookie buffer.
     uint32_t cookieSize = e->enc_.GetMagicCookieSize(e->outf_.mChannelsPerFrame);
-    char cookie[cookieSize];
+	char* cookie = (char*)alloca(sizeof(char) * (cookieSize));
     e->enc_.GetMagicCookie(cookie, &cookieSize);
 
     // Init self.


### PR DESCRIPTION
Added inline redefine.
Fixed conflict with winioctl.h

It does not pass the last test though on Windows (in the encoder). I only need the decoder though.
